### PR TITLE
Bug/header always says dark mode

### DIFF
--- a/pokemon-project/src/App.js
+++ b/pokemon-project/src/App.js
@@ -22,7 +22,7 @@ function App() {
   ) => {
     const newData = data.filter((item) => {
       if (type) {
-        return item.type[0] === type || item.type[1] === type;
+        return item.type.includes(type);
       } else if (size) {
         const weightInt = item.weight.split(" ")[0];
         return size === "small" ? weightInt < 5 : weightInt > 100;

--- a/pokemon-project/src/components/Header.js
+++ b/pokemon-project/src/components/Header.js
@@ -21,7 +21,7 @@ const Header = (props) => {
       <section className="darkmode-shiny-dropdown">
         <menu className="darkmode-shiny-section">
           <div className="darkmode-section">
-            <div className="logo">
+            <div className="logo" data-testid="logo">
               {isDarkMode ? "Dark Mode" : "Light Mode"}
             </div>
             <button

--- a/pokemon-project/src/components/Header.js
+++ b/pokemon-project/src/components/Header.js
@@ -11,7 +11,6 @@ import linkMaker from "../utils/Headerutils/linkMaker";
 
 const Header = (props) => {
   const [isDarkMode, setDarkMode] = useDarkMode();
-  console.log("isDarkMode:", isDarkMode);
 
   const { changeDisplay, isShiny, setIsShiny } = props;
   return (

--- a/pokemon-project/src/components/Header.js
+++ b/pokemon-project/src/components/Header.js
@@ -11,6 +11,7 @@ import linkMaker from "../utils/Headerutils/linkMaker";
 
 const Header = (props) => {
   const [isDarkMode, setDarkMode] = useDarkMode();
+  console.log("isDarkMode:", isDarkMode);
 
   const { changeDisplay, isShiny, setIsShiny } = props;
   return (
@@ -21,7 +22,9 @@ const Header = (props) => {
       <section className="darkmode-shiny-dropdown">
         <menu className="darkmode-shiny-section">
           <div className="darkmode-section">
-            <div className="logo">Dark Mode</div>
+            <div className="logo">
+              {isDarkMode ? "Dark Mode" : "Light Mode"}
+            </div>
             <button
               className="toggle_btn"
               data-testid="toggle_btn"

--- a/pokemon-project/src/tests/Header.test.js
+++ b/pokemon-project/src/tests/Header.test.js
@@ -24,4 +24,10 @@ test("Renders the expected segments of the header", () => {
 
 test("'Dark Mode' text changes to 'Light Mode' and vice versa when you click dark mode toggle logo", () => {
   render(<Header />);
+  const darkModeToggleLogo = screen.getByTestId("logo");
+  const darkModeText = screen.queryByText(/dark mode/i);
+  const lightModeText = screen.queryByText(/light mode/i);
+
+  expect(darkModeText).not.toBeVisible();
+  expect(lightModeText).toBeVisible();
 });

--- a/pokemon-project/src/tests/Header.test.js
+++ b/pokemon-project/src/tests/Header.test.js
@@ -24,10 +24,18 @@ test("Renders the expected segments of the header", () => {
 
 test("'Dark Mode' text changes to 'Light Mode' and vice versa when you click dark mode toggle logo", () => {
   render(<Header />);
-  const darkModeToggleLogo = screen.getByTestId("logo");
+  const darkModeToggleLogo = screen.getByTestId("toggle_btn");
   const darkModeText = screen.queryByText(/dark mode/i);
   const lightModeText = screen.queryByText(/light mode/i);
 
   expect(darkModeText).not.toBeVisible();
   expect(lightModeText).toBeVisible();
+
+  userEvent.click(darkModeToggleLogo);
+
+  const newDarkModeText = screen.queryByText(/dark mode/i);
+  const newLightModeText = screen.queryByText(/light mode/i);
+
+  expect(newDarkModeText).toBeVisible();
+  expect(newLightModeText).not.toBeVisible();
 });

--- a/pokemon-project/src/tests/Header.test.js
+++ b/pokemon-project/src/tests/Header.test.js
@@ -22,20 +22,15 @@ test("Renders the expected segments of the header", () => {
 
 //I tried to test that the dropdown only appears when you click on the Display Options button, but the testing said the dropdown was always visible no matter what. I tried document.queryselector, screen.getByTestID, and others. Not sure what I was doing wrong.
 
-test("'Dark Mode' text changes to 'Light Mode' and vice versa when you click dark mode toggle logo", () => {
+test("'Dark Mode' text changes to 'Light Mode' and vice versa when you click dark mode toggle logo", async () => {
   render(<Header />);
   const darkModeToggleLogo = screen.getByTestId("toggle_btn");
-  const darkModeText = screen.queryByText(/dark mode/i);
-  const lightModeText = screen.queryByText(/light mode/i);
 
-  expect(darkModeText).not.toBeVisible();
-  expect(lightModeText).toBeVisible();
+  expect(screen.queryByText(/dark mode/i)).not.toBeVisible();
+  expect(screen.queryByText(/light mode/i)).toBeVisible();
 
   userEvent.click(darkModeToggleLogo);
 
-  const newDarkModeText = screen.queryByText(/dark mode/i);
-  const newLightModeText = screen.queryByText(/light mode/i);
-
-  expect(newDarkModeText).toBeVisible();
-  expect(newLightModeText).not.toBeVisible();
+  expect(screen.queryByText(/dark mode/i)).toBeVisible();
+  expect(screen.queryByText(/light mode/i)).not.toBeVisible();
 });

--- a/pokemon-project/src/tests/Header.test.js
+++ b/pokemon-project/src/tests/Header.test.js
@@ -1,6 +1,7 @@
 import Header from "../components/Header";
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
+import userEvent from "@testing-library/user-event";
 
 test("Component renders without errors", () => {
   render(<Header />);
@@ -21,4 +22,6 @@ test("Renders the expected segments of the header", () => {
 
 //I tried to test that the dropdown only appears when you click on the Display Options button, but the testing said the dropdown was always visible no matter what. I tried document.queryselector, screen.getByTestID, and others. Not sure what I was doing wrong.
 
-test("'Dark Mode' text changes to 'Light Mode' and vice versa when you click dark mode toggle logo", () => {});
+test("'Dark Mode' text changes to 'Light Mode' and vice versa when you click dark mode toggle logo", () => {
+  render(<Header />);
+});

--- a/pokemon-project/src/tests/Header.test.js
+++ b/pokemon-project/src/tests/Header.test.js
@@ -20,3 +20,5 @@ test("Renders the expected segments of the header", () => {
 });
 
 //I tried to test that the dropdown only appears when you click on the Display Options button, but the testing said the dropdown was always visible no matter what. I tried document.queryselector, screen.getByTestID, and others. Not sure what I was doing wrong.
+
+test("'Dark Mode' text changes to 'Light Mode' and vice versa when you click dark mode toggle logo", () => {});


### PR DESCRIPTION
PROBLEM:
.When I click the Dark Mode toggle logo, the text still says "Dark Mode" whether I'm in light or dark mode

SOLUTION:
.This was very simple. 
+I just added an expression to Header.js that checked whether the app is in Dark Mode or Light Mode and made it display the correct text ("Dark Mode" and "Light Mode" respectively).
+Also added Header.test.js unit testing to make sure this text toggle behaves as expected
+Confirmed that the new test and all other tests are still passing
+Manually tested application to make sure everything is working as expected